### PR TITLE
Add responsive design for mobile and tablet devices

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,12 +2,14 @@
   <div id="app">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
     <FloatingActionButton id="fab"/>
-    <Greeting id="greeting" :msg="greetingMsg"/>
-    <Window id="window"/>
-    <div class="footer">
+    <main class="content">
+      <Greeting id="greeting" :msg="greetingMsg"/>
+      <Window id="window"/>
+    </main>
+    <footer class="footer">
       <span class="left-align">Made with <i class="far fa-heart"/> using <a class="link fab fa-vuejs" href="https://vuejs.org" role="button"/></span>
       <span class="right-align">Updated: {{ updatedDate }}</span>
-    </div>
+    </footer>
   </div>
 </template>
 
@@ -21,43 +23,8 @@ const updatedDate = new Date().getFullYear().toString()
 </script>
 
 <style>
-#app {
-  font-family: 'Avenir', Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: #171D1C;
-}
-
-@media only screen and (max-width : 700px) {
-  #window {
-    display: none !important;
-  }
-  #greeting {
-    padding-top: 15vh;
-  }
-}
-
-.left-align {
-  padding-left: 5px;
-  float: left;
-}
-
-.right-align {
-  padding-right: 5px;
-  float: right;
-}
-
-.footer {
-  font-size: 10pt;
-  width: 100%;
-  position: fixed;
-  text-align: left;
-  border-top: #cccccc solid 1px;
-  background-color: #DBDBDB;
-  height: 20px;
-  left: 0;
-  bottom: 0;
+* {
+  box-sizing: border-box;
 }
 
 body, html {
@@ -68,8 +35,68 @@ body, html {
   padding: 0;
 }
 
+#app {
+  font-family: 'Avenir', Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: center;
+  color: #171D1C;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.content {
+  flex: 1;
+  padding-bottom: 30px;
+}
+
+.left-align {
+  padding-left: 10px;
+  float: left;
+}
+
+.right-align {
+  padding-right: 10px;
+  float: right;
+}
+
+.footer {
+  font-size: 10pt;
+  width: 100%;
+  position: fixed;
+  text-align: left;
+  border-top: #cccccc solid 1px;
+  background-color: #DBDBDB;
+  height: 24px;
+  line-height: 24px;
+  left: 0;
+  bottom: 0;
+  z-index: 50;
+}
+
 .link {
   color: #171D1C;
   text-decoration: none;
+}
+
+/* Mobile: stack vertically, compact spacing */
+@media (max-width: 768px) {
+  .content {
+    padding: 10px;
+    padding-bottom: 34px;
+  }
+
+  .footer {
+    font-size: 9pt;
+  }
+
+  .left-align {
+    padding-left: 5px;
+  }
+
+  .right-align {
+    padding-right: 5px;
+  }
 }
 </style>

--- a/src/components/FinderEmu.vue
+++ b/src/components/FinderEmu.vue
@@ -119,14 +119,26 @@ const projectDataMap = new Map<string, ProjectData>([
 .finder {
   color: black;
   background-color: white;
+  height: 100%;
   overflow: auto;
-  height: inherit;
+  padding: 10px;
 }
 
 .grid {
   display: flex;
   justify-content: center;
-  flex-direction: row;
   flex-wrap: wrap;
+  gap: 5px;
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+  .finder {
+    padding: 5px;
+  }
+
+  .grid {
+    gap: 0;
+  }
 }
 </style>

--- a/src/components/FinderItem.vue
+++ b/src/components/FinderItem.vue
@@ -15,40 +15,118 @@ defineProps<{
 
 <style scoped>
 .item {
-  margin: 30px;
+  margin: 15px;
   text-decoration: none;
-  padding: 30px 20px 10px;
+  padding: 15px 10px 10px;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background-color 0.2s;
 }
 
 .item:hover {
-  background-color: whitesmoke;
-  border-radius: 10px 10px 10px 10px;
+  background-color: rgba(0, 0, 0, 0.05);
 }
 
 .folder {
-  width: 100px;
-  height: 65px;
+  width: 80px;
+  height: 52px;
   position: relative;
-  background-color: skyblue;
+  background-color: #5AC8FA;
   border-radius: 0 6px 6px 6px;
-  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.5);
+  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+  margin: 0 auto;
 }
 
 .folder::before {
-  color: lightblue;
   content: '';
-  width: 50%;
-  height: 10px;
-  border-radius: 6px 10px 0 0;
-  background-color: lightblue;
+  width: 40%;
+  height: 8px;
+  border-radius: 4px 4px 0 0;
+  background-color: #4AB8E8;
   position: absolute;
-  top: -10px;
-  left: 0px;
+  top: -8px;
+  left: 0;
 }
 
 .label {
-  width: 100px;
-  color: black;
-  padding-top: 20px;
+  color: #333;
+  padding-top: 10px;
+  font-size: 12px;
+  text-align: center;
+  word-wrap: break-word;
+  max-width: 90px;
+  margin: 0 auto;
+}
+
+/* Tablet */
+@media (max-width: 1024px) {
+  .item {
+    margin: 12px;
+    padding: 12px 8px 8px;
+  }
+
+  .folder {
+    width: 70px;
+    height: 45px;
+  }
+
+  .folder::before {
+    height: 7px;
+    top: -7px;
+  }
+
+  .label {
+    font-size: 11px;
+    max-width: 80px;
+  }
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+  .item {
+    margin: 8px;
+    padding: 10px 6px 6px;
+  }
+
+  .folder {
+    width: 60px;
+    height: 40px;
+    border-radius: 0 4px 4px 4px;
+  }
+
+  .folder::before {
+    height: 6px;
+    top: -6px;
+    border-radius: 3px 3px 0 0;
+  }
+
+  .label {
+    font-size: 10px;
+    padding-top: 8px;
+    max-width: 70px;
+  }
+}
+
+/* Small mobile */
+@media (max-width: 480px) {
+  .item {
+    margin: 5px;
+    padding: 8px 4px 4px;
+  }
+
+  .folder {
+    width: 50px;
+    height: 32px;
+  }
+
+  .folder::before {
+    height: 5px;
+    top: -5px;
+  }
+
+  .label {
+    font-size: 9px;
+    max-width: 60px;
+  }
 }
 </style>

--- a/src/components/Greeting.vue
+++ b/src/components/Greeting.vue
@@ -1,11 +1,11 @@
 <template>
   <div id="greeting">
     <img class="pro-pic" alt="Profile Pic" src="../assets/pro.png">
-    <h2>{{ msg }}</h2>
-    <div>
-      <a href="https://www.linkedin.com/in/tyler-howard-b874b8118/" role="button" class="btn-link fab fa-linkedin fa-2x"></a>
-      <a href="https://github.com/tylernhoward" role="button" class="btn-link fab fa-github fa-2x"></a>
-      <a href="https://flickr.com/photos/faintcolors" role="button" class="btn-link fab fa-flickr fa-2x"></a>
+    <h2 class="greeting-text">{{ msg }}</h2>
+    <div class="social-links">
+      <a href="https://www.linkedin.com/in/tyler-howard-b874b8118/" role="button" class="btn-link fab fa-linkedin fa-2x" aria-label="LinkedIn"></a>
+      <a href="https://github.com/tylernhoward" role="button" class="btn-link fab fa-github fa-2x" aria-label="GitHub"></a>
+      <a href="https://flickr.com/photos/faintcolors" role="button" class="btn-link fab fa-flickr fa-2x" aria-label="Flickr"></a>
     </div>
   </div>
 </template>
@@ -16,27 +16,92 @@ defineProps<{
 }>()
 </script>
 
-<style>
-.pro-pic {
-  border-radius: 50%;
-  border: #315C2B solid 3px;
-  max-width: 175px;
-}
-
+<style scoped>
 #greeting {
   padding: 20px;
 }
 
+.pro-pic {
+  border-radius: 50%;
+  border: #315C2B solid 3px;
+  width: 150px;
+  height: 150px;
+  object-fit: cover;
+}
+
+.greeting-text {
+  margin: 15px 0;
+  font-size: 1.5rem;
+}
+
+.social-links {
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+}
+
 .btn-link {
   color: #171D1C;
-  padding-left: 10px;
-  padding-right: 10px;
   text-decoration: none;
+  transition: color 0.2s, transform 0.2s;
 }
 
 .btn-link:hover {
   color: #138A36;
-  text-decoration: none;
-  cursor: pointer;
+  transform: scale(1.1);
+}
+
+/* Tablet */
+@media (max-width: 1024px) {
+  #greeting {
+    padding: 15px;
+  }
+
+  .pro-pic {
+    width: 130px;
+    height: 130px;
+  }
+
+  .greeting-text {
+    font-size: 1.3rem;
+  }
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+  #greeting {
+    padding: 10px;
+  }
+
+  .pro-pic {
+    width: 100px;
+    height: 100px;
+    border-width: 2px;
+  }
+
+  .greeting-text {
+    font-size: 1.1rem;
+    margin: 10px 0;
+  }
+
+  .social-links {
+    gap: 15px;
+  }
+
+  .btn-link {
+    font-size: 1.5em !important;
+  }
+}
+
+/* Small mobile */
+@media (max-width: 480px) {
+  .pro-pic {
+    width: 80px;
+    height: 80px;
+  }
+
+  .greeting-text {
+    font-size: 1rem;
+  }
 }
 </style>

--- a/src/components/ProjectModal.vue
+++ b/src/components/ProjectModal.vue
@@ -1,26 +1,32 @@
 <template>
-  <div name="modal" v-if="showModal">
-    <div class="modal-mask" @click="closeModal">
-      <div class="modal-wrapper">
-        <div class="modal-container" @click.stop>
-          <div class="modal-bar">
-            <div class="modal-close" @click="closeModal"></div>
-            <span class="modal-header">{{ name }}</span>
-          </div>
-          <div class="modal-body">
-            <img class="image-box" v-if="project?.image" :src="project.image"/>
-            <div class="description">
-              <p>{{ project?.description }}</p>
-              <div class="btn-group">
-                <a class="modal-btn" v-if="project?.githubUrl" :href="project.githubUrl" target="_blank">Github <i class="fab fa-github"></i></a>
-                <a class="modal-btn" v-if="project?.exploreUrl" :href="project.exploreUrl" target="_blank">Explore <i class="far fa-compass"></i></a>
+  <Teleport to="body">
+    <Transition name="modal">
+      <div v-if="showModal" class="modal-mask" @click="closeModal">
+        <div class="modal-wrapper">
+          <div class="modal-container" @click.stop>
+            <div class="modal-bar">
+              <div class="modal-close" @click="closeModal"></div>
+              <span class="modal-header">{{ name }}</span>
+            </div>
+            <div class="modal-body">
+              <img class="image-box" v-if="project?.image" :src="project.image" :alt="name"/>
+              <div class="description">
+                <p>{{ project?.description }}</p>
+                <div class="btn-group">
+                  <a class="modal-btn" v-if="project?.githubUrl" :href="project.githubUrl" target="_blank" rel="noopener">
+                    <i class="fab fa-github"></i> Github
+                  </a>
+                  <a class="modal-btn" v-if="project?.exploreUrl" :href="project.exploreUrl" target="_blank" rel="noopener">
+                    <i class="far fa-compass"></i> Explore
+                  </a>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  </div>
+    </Transition>
+  </Teleport>
 </template>
 
 <script setup lang="ts">
@@ -49,120 +55,217 @@ function closeModal() {
   showModal.value = false
 }
 
+function handleEscape(e: KeyboardEvent) {
+  if (e.key === 'Escape') closeModal()
+}
+
 onMounted(() => {
   eventBus.on('toggle-modal', handleToggleModal)
+  document.addEventListener('keydown', handleEscape)
 })
 
 onUnmounted(() => {
   eventBus.off('toggle-modal', handleToggleModal)
+  document.removeEventListener('keydown', handleEscape)
 })
 </script>
 
 <style scoped>
-p {
-  line-height: 2;
-  padding: 10px;
-}
-
 .modal-mask {
   position: fixed;
-  z-index: 100;
+  z-index: 1000;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, .5);
-  display: table;
-  transition: opacity .3s ease;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
 }
 
 .modal-wrapper {
-  display: table-cell;
-  vertical-align: middle;
+  width: 100%;
+  max-width: 800px;
+  max-height: 90vh;
+  overflow: auto;
 }
 
 .modal-container {
-  width: 70%;
-  height: fit-content;
-  margin: 0px auto;
   background-color: #fff;
-  border-radius: 6px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, .33);
-  transition: all .3s ease;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
 }
 
 .modal-bar {
-  border-radius: 6px 6px 0px 0px;
-  background-color: gainsboro;
-  width: 100%;
-  height: 20px;
+  background-color: #e8e8e8;
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .modal-close {
-  z-index: 2;
-  margin: 3px;
-  background-color: tomato;
-  border-radius: 50%;
-  border: #cccccc solid 1px;
   width: 12px;
   height: 12px;
-  position: relative;
-  top: 0;
-  float: left;
+  background-color: #ff5f57;
+  border-radius: 50%;
   cursor: pointer;
+  flex-shrink: 0;
+}
+
+.modal-close:hover {
+  opacity: 0.8;
+}
+
+.modal-header {
+  font-size: 14px;
+  color: #333;
+  font-weight: 500;
 }
 
 .modal-body {
   display: flex;
-  padding: 10px;
+  padding: 20px;
+  gap: 20px;
 }
 
 .image-box {
-  width: 50%;
-  height: 100%;
+  width: 45%;
+  max-width: 350px;
+  height: auto;
+  object-fit: contain;
+  border-radius: 4px;
+  flex-shrink: 0;
 }
 
 .description {
-  width: 100%;
+  flex: 1;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding-left: 20px;
-  text-align: left;
+}
+
+.description p {
+  line-height: 1.7;
+  margin: 0 0 15px 0;
+  font-size: 14px;
+  color: #444;
 }
 
 .btn-group {
-  width: 100%;
   display: flex;
-  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .modal-btn {
-  color: black;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #333;
   text-decoration: none;
-  width: fit-content;
-  padding: 5px;
-  margin: 0px 5px;
-  border-radius: 5px 5px 5px 5px;
-  background-color: gainsboro;
+  padding: 8px 16px;
+  border-radius: 6px;
+  background-color: #f0f0f0;
+  font-size: 13px;
+  transition: all 0.2s;
 }
 
 .modal-btn:hover {
-  padding: 4px;
-  border: #87FF65 solid 1px;
+  background-color: #28262C;
+  color: #87FF65;
 }
 
-.modal-enter {
-  opacity: 0;
-}
-
+/* Transitions */
+.modal-enter-active,
 .modal-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.modal-enter-from,
+.modal-leave-to {
   opacity: 0;
 }
 
-.modal-enter .modal-container,
+.modal-enter-active .modal-container,
 .modal-leave-active .modal-container {
-  -webkit-transform: scale(1.1);
-  transform: scale(1.1);
+  transition: transform 0.25s ease;
+}
+
+.modal-enter-from .modal-container,
+.modal-leave-to .modal-container {
+  transform: scale(0.95);
+}
+
+/* Tablet */
+@media (max-width: 1024px) {
+  .modal-body {
+    padding: 15px;
+    gap: 15px;
+  }
+
+  .image-box {
+    width: 40%;
+  }
+
+  .description p {
+    font-size: 13px;
+  }
+}
+
+/* Mobile - stack vertically */
+@media (max-width: 768px) {
+  .modal-mask {
+    padding: 10px;
+  }
+
+  .modal-body {
+    flex-direction: column;
+    padding: 15px;
+    gap: 15px;
+  }
+
+  .image-box {
+    width: 100%;
+    max-width: none;
+    max-height: 200px;
+    object-fit: cover;
+  }
+
+  .description p {
+    font-size: 13px;
+    line-height: 1.6;
+  }
+
+  .btn-group {
+    justify-content: center;
+  }
+
+  .modal-btn {
+    padding: 10px 20px;
+  }
+}
+
+/* Small mobile */
+@media (max-width: 480px) {
+  .modal-header {
+    font-size: 13px;
+  }
+
+  .modal-body {
+    padding: 12px;
+  }
+
+  .description p {
+    font-size: 12px;
+  }
+
+  .modal-btn {
+    font-size: 12px;
+    padding: 8px 14px;
+  }
 }
 </style>

--- a/src/components/TerminalEmu.vue
+++ b/src/components/TerminalEmu.vue
@@ -2,8 +2,10 @@
   <div class="terminal">
     <div class="termContent">
       <div class="output" v-if="output">{{ output }}</div>
-      <span>{{ inputLabel }}&nbsp;</span>
-      <input v-on:keyup.enter="commandEntered" v-model="command" class="commandInput" autofocus/>
+      <div class="input-line">
+        <span class="prompt">{{ inputLabel }}&nbsp;</span>
+        <input v-on:keyup.enter="commandEntered" v-model="command" class="commandInput" autofocus/>
+      </div>
     </div>
   </div>
 </template>
@@ -152,35 +154,70 @@ onMounted(() => {
 </script>
 
 <style scoped>
+.terminal {
+  color: #87FF65;
+  background-color: #28262C;
+  height: 100%;
+  overflow: auto;
+}
+
+.termContent {
+  padding: 20px 15px;
+  text-align: left;
+  font-family: 'Monaco', 'Courier New', monospace;
+  font-size: 14px;
+  min-height: 100%;
+}
+
 .output {
   white-space: pre-wrap;
+  word-break: break-word;
+  margin-bottom: 10px;
+}
+
+.input-line {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.prompt {
+  white-space: nowrap;
 }
 
 .commandInput {
-  padding-top: 5px;
-  width: 80%;
-  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 100px;
   font-family: inherit;
   font-size: inherit;
   border: none;
   background: transparent;
   outline: none;
   color: inherit;
+  padding: 0;
 }
 
-.terminal {
-  color: #87FF65;
-  background-color: #28262C;
-  overflow: auto;
-  height: inherit;
+/* Tablet */
+@media (max-width: 1024px) {
+  .termContent {
+    font-size: 13px;
+    padding: 15px 12px;
+  }
 }
 
-.termContent {
-  overflow: auto;
-  padding-top: 25px;
-  padding-left: 10px;
-  text-align: left;
-  font-family: 'Monaco', 'Courier New';
-  font-size: 14px;
+/* Mobile */
+@media (max-width: 768px) {
+  .termContent {
+    font-size: 12px;
+    padding: 12px 10px;
+  }
+}
+
+/* Small mobile */
+@media (max-width: 480px) {
+  .termContent {
+    font-size: 11px;
+    padding: 10px 8px;
+  }
 }
 </style>

--- a/src/components/Window.vue
+++ b/src/components/Window.vue
@@ -3,16 +3,18 @@
     <div class="window">
       <div class="bar">
         <div class="circle-bar">
-          <div class="circle" style="background-color:tomato;" @click="showFinder = false; windowTitle = 'Terminal'"></div>
-          <div class="circle" style="background-color:gold;" @click="toggleFinder"></div>
-          <div class="circle" style="background-color:limegreen;"></div>
+          <div class="circle close" @click="showFinder = false; windowTitle = 'Terminal'"></div>
+          <div class="circle minimize" @click="toggleFinder"></div>
+          <div class="circle maximize"></div>
         </div>
         <div class="title-bar">
           <span class="title">{{ windowTitle }}</span>
         </div>
       </div>
-      <TerminalEmu v-if="!showFinder" :inputLabel="label"/>
-      <FinderEmu v-if="showFinder"/>
+      <div class="window-content">
+        <TerminalEmu v-if="!showFinder" :inputLabel="label"/>
+        <FinderEmu v-if="showFinder"/>
+      </div>
     </div>
   </div>
 </template>
@@ -45,44 +47,119 @@ onUnmounted(() => {
 .container {
   display: flex;
   justify-content: center;
+  padding: 0 20px;
 }
 
 .window {
+  width: 100%;
+  max-width: 900px;
   height: 50vh;
-  box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.5);
-  width: 70%;
-  overflow: auto;
+  min-height: 300px;
+  box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.3);
+  border-radius: 6px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .bar {
-  position: absolute;
-  width: inherit;
-  height: 20px;
+  height: 28px;
+  min-height: 28px;
   background-color: #DBDBDB;
-  z-index: 99 !important;
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+  position: relative;
 }
 
 .circle-bar {
   display: flex;
-  justify-content: left;
+  gap: 6px;
+  z-index: 2;
 }
 
 .circle {
-  z-index: 2;
-  margin: 3px;
-  background-color: #fd9494;
-  border-radius: 50%;
-  border: #cccccc solid 1px;
   width: 12px;
   height: 12px;
+  border-radius: 50%;
+  border: #cccccc solid 1px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.circle:hover {
+  opacity: 0.8;
+}
+
+.circle.close {
+  background-color: #ff5f57;
+}
+
+.circle.minimize {
+  background-color: #ffbd2e;
+}
+
+.circle.maximize {
+  background-color: #28c840;
 }
 
 .title-bar {
-  z-index: 1;
-  top: -20px;
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  position: absolute;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 13px;
+  color: #4d4d4d;
+  pointer-events: none;
+}
+
+.window-content {
+  flex: 1;
+  overflow: auto;
+}
+
+/* Tablet */
+@media (max-width: 1024px) {
+  .container {
+    padding: 0 15px;
+  }
+
+  .window {
+    height: 45vh;
+  }
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+  .container {
+    padding: 0 10px;
+  }
+
+  .window {
+    height: 40vh;
+    min-height: 250px;
+  }
+
+  .bar {
+    height: 24px;
+    min-height: 24px;
+  }
+
+  .circle {
+    width: 10px;
+    height: 10px;
+  }
+
+  .title-bar {
+    font-size: 12px;
+  }
+}
+
+/* Small mobile */
+@media (max-width: 480px) {
+  .window {
+    height: 35vh;
+    min-height: 200px;
+  }
 }
 </style>


### PR DESCRIPTION
- Terminal window now visible on mobile (was hidden before)
- Responsive breakpoints: mobile (<768px), tablet (<1024px), small mobile (<480px)
- Window component: fluid width with max-width, responsive height
- Greeting: scaled profile picture and text sizes
- FinderItem: smaller folders on mobile, adjusted spacing
- ProjectModal: stacks image/description vertically on mobile
- TerminalEmu: responsive font sizes and padding
- Improved window bar styling with proper macOS colors
- Added Teleport for modal to fix z-index issues