### PR TITLE
Modernize Terminal and Finder visuals

### DIFF
--- a/src/components/FileItem.vue
+++ b/src/components/FileItem.vue
@@ -1,0 +1,292 @@
+<template>
+  <a class="item" @click="$emit('open-file')">
+    <div class="file" :class="iconClass">
+      <div class="file-body">
+        <div class="file-fold"></div>
+        <div class="file-decoration">
+          <!-- Text file: lines -->
+          <template v-if="file.type === 'text'">
+            <div class="text-line"></div>
+            <div class="text-line short"></div>
+            <div class="text-line"></div>
+            <div class="text-line short"></div>
+          </template>
+          <!-- Image file: thumbnail icon -->
+          <template v-else-if="file.type === 'image'">
+            <div class="image-icon">
+              <div class="image-mountain"></div>
+              <div class="image-sun"></div>
+            </div>
+          </template>
+          <!-- Link files: arrow -->
+          <template v-else>
+            <div class="link-arrow">
+              <svg viewBox="0 0 16 16" fill="currentColor">
+                <path d="M5 11L11 5M11 5H6M11 5V10" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </div>
+          </template>
+        </div>
+      </div>
+    </div>
+    <div class="label">{{ file.name }}</div>
+  </a>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { FileItem as FileItemType } from './ProjectData'
+
+const props = defineProps<{
+  file: FileItemType
+}>()
+
+defineEmits<{
+  'open-file': []
+}>()
+
+const iconClass = computed(() => {
+  switch (props.file.type) {
+    case 'text': return 'file-text'
+    case 'image': return 'file-image'
+    case 'link-github': return 'file-link'
+    case 'link-explore': return 'file-link'
+    default: return ''
+  }
+})
+</script>
+
+<style scoped>
+.item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-decoration: none;
+  padding: 12px 8px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  width: 100%;
+  max-width: 100px;
+}
+
+.item:hover {
+  background: rgba(0, 122, 255, 0.1);
+}
+
+.item:hover .label {
+  color: #007AFF;
+}
+
+.item:active {
+  background: rgba(0, 122, 255, 0.2);
+}
+
+.file {
+  width: 52px;
+  height: 64px;
+  position: relative;
+  transition: transform 0.2s ease;
+}
+
+.item:hover .file {
+  transform: scale(1.05);
+}
+
+.file-body {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(180deg, #FFFFFF 0%, #F0F0F0 100%);
+  border-radius: 4px;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.12),
+    0 0 0 1px rgba(0, 0, 0, 0.08);
+  position: relative;
+  overflow: hidden;
+}
+
+.file-fold {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 14px;
+  height: 14px;
+  background: linear-gradient(135deg, transparent 50%, #E0E0E0 50%);
+  border-bottom-left-radius: 4px;
+}
+
+.file-fold::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 14px;
+  height: 14px;
+  background: linear-gradient(135deg, #F5F5F5 50%, transparent 50%);
+  box-shadow: -1px 1px 1px rgba(0, 0, 0, 0.05);
+}
+
+.file-decoration {
+  position: absolute;
+  inset: 18px 8px 10px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+}
+
+/* Text file styling */
+.file-text .file-body {
+  background: linear-gradient(180deg, #FFFFFF 0%, #F8F8F8 100%);
+}
+
+.text-line {
+  width: 100%;
+  height: 3px;
+  background: #D0D0D0;
+  border-radius: 1px;
+}
+
+.text-line.short {
+  width: 70%;
+  align-self: flex-start;
+}
+
+/* Image file styling */
+.file-image .file-body {
+  background: linear-gradient(180deg, #E8F4FF 0%, #D0E8FF 100%);
+}
+
+.image-icon {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  background: linear-gradient(180deg, #87CEEB 0%, #5DADE2 100%);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.image-mountain {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 60%;
+  background: linear-gradient(135deg, #2ECC71 0%, #27AE60 100%);
+  clip-path: polygon(0 100%, 30% 30%, 50% 60%, 70% 20%, 100% 100%);
+}
+
+.image-sun {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 8px;
+  height: 8px;
+  background: #F1C40F;
+  border-radius: 50%;
+  box-shadow: 0 0 4px rgba(241, 196, 15, 0.5);
+}
+
+/* Link file styling */
+.file-link .file-body {
+  background: linear-gradient(180deg, #FFF8E8 0%, #FFE8C0 100%);
+}
+
+.link-arrow {
+  width: 24px;
+  height: 24px;
+  color: #F39C12;
+}
+
+.link-arrow svg {
+  width: 100%;
+  height: 100%;
+}
+
+.label {
+  margin-top: 8px;
+  font-size: 11px;
+  font-weight: 400;
+  color: #1D1D1F;
+  text-align: center;
+  line-height: 1.3;
+  word-break: break-word;
+  max-width: 90px;
+  transition: color 0.15s ease;
+}
+
+@media only screen and (max-width: 768px) {
+  .item {
+    padding: 8px 4px;
+    max-width: 80px;
+  }
+
+  .file {
+    width: 44px;
+    height: 54px;
+  }
+
+  .file-fold {
+    width: 10px;
+    height: 10px;
+  }
+
+  .file-fold::before {
+    width: 10px;
+    height: 10px;
+  }
+
+  .file-decoration {
+    inset: 14px 6px 8px;
+    gap: 3px;
+  }
+
+  .text-line {
+    height: 2px;
+  }
+
+  .label {
+    font-size: 10px;
+    max-width: 75px;
+    margin-top: 6px;
+  }
+}
+
+@media only screen and (max-width: 480px) {
+  .item {
+    padding: 6px 2px;
+    max-width: 70px;
+  }
+
+  .file {
+    width: 38px;
+    height: 46px;
+  }
+
+  .file-fold {
+    width: 8px;
+    height: 8px;
+  }
+
+  .file-fold::before {
+    width: 8px;
+    height: 8px;
+  }
+
+  .file-decoration {
+    inset: 12px 5px 6px;
+    gap: 2px;
+  }
+
+  .link-arrow {
+    width: 18px;
+    height: 18px;
+  }
+
+  .label {
+    font-size: 9px;
+    max-width: 65px;
+  }
+}
+</style>

--- a/src/components/FileModal.vue
+++ b/src/components/FileModal.vue
@@ -1,35 +1,27 @@
 <template>
   <Teleport to="body">
     <Transition name="modal">
-      <div v-if="showModal" class="modal-mask" @click="closeModal">
+      <div v-if="show" class="modal-mask" @click="$emit('close')">
         <div class="modal-wrapper">
-          <div class="modal-container" @click.stop>
+          <div class="modal-container" :class="{ 'image-modal': file?.type === 'image' }" @click.stop>
             <div class="modal-bar">
               <div class="modal-traffic-lights">
-                <button class="modal-close" @click="closeModal" aria-label="Close">
+                <button class="modal-close" @click="$emit('close')" aria-label="Close">
                   <svg viewBox="0 0 12 12"><path d="M3.5 3.5l5 5M8.5 3.5l-5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
                 </button>
                 <div class="modal-circle minimize"></div>
                 <div class="modal-circle maximize"></div>
               </div>
-              <span class="modal-header">{{ name }}</span>
+              <span class="modal-header">{{ file?.name }}</span>
             </div>
             <div class="modal-body">
-              <div class="modal-image-container" v-if="project?.image">
-                <img class="image-box" :src="project.image" :alt="name"/>
+              <!-- Text content -->
+              <div v-if="file?.type === 'text'" class="text-content">
+                <p>{{ file.content }}</p>
               </div>
-              <div class="description">
-                <p>{{ project?.description }}</p>
-                <div class="btn-group">
-                  <a class="modal-btn github" v-if="project?.githubUrl" :href="project.githubUrl" target="_blank" rel="noopener noreferrer">
-                    <i class="fab fa-github"></i>
-                    <span>View on GitHub</span>
-                  </a>
-                  <a class="modal-btn explore" v-if="project?.exploreUrl" :href="project.exploreUrl" target="_blank" rel="noopener noreferrer">
-                    <i class="fas fa-external-link-alt"></i>
-                    <span>Explore</span>
-                  </a>
-                </div>
+              <!-- Image content -->
+              <div v-else-if="file?.type === 'image'" class="image-content">
+                <img :src="file.content" :alt="file.name" />
               </div>
             </div>
           </div>
@@ -40,38 +32,16 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
-import type { ProjectData } from './ProjectData'
-import { eventBus } from '../eventBus'
+import type { FileItem } from './ProjectData'
 
-const props = defineProps<{
-  data: Map<string, ProjectData>
+defineProps<{
+  show: boolean
+  file: FileItem | null
 }>()
 
-const showModal = ref(false)
-const name = ref('')
-const project = ref<ProjectData | undefined>(undefined)
-
-function handleToggleModal(projectName: string | undefined) {
-  if (projectName) {
-    const projectInfo = props.data.get(projectName)
-    name.value = projectName
-    project.value = projectInfo
-  }
-  showModal.value = !showModal.value
-}
-
-function closeModal() {
-  showModal.value = false
-}
-
-onMounted(() => {
-  eventBus.on('toggle-modal', handleToggleModal)
-})
-
-onUnmounted(() => {
-  eventBus.off('toggle-modal', handleToggleModal)
-})
+defineEmits<{
+  close: []
+}>()
 </script>
 
 <style scoped>
@@ -89,7 +59,7 @@ onUnmounted(() => {
 
 .modal-wrapper {
   width: 100%;
-  max-width: 700px;
+  max-width: 600px;
 }
 
 .modal-container {
@@ -100,6 +70,10 @@ onUnmounted(() => {
     0 22px 70px 4px rgba(0, 0, 0, 0.25),
     0 0 0 1px rgba(0, 0, 0, 0.1);
   overflow: hidden;
+}
+
+.modal-container.image-modal {
+  max-width: 800px;
 }
 
 .modal-bar {
@@ -179,81 +153,47 @@ onUnmounted(() => {
 }
 
 .modal-body {
-  display: flex;
-  gap: 24px;
   padding: 24px;
 }
 
-.modal-image-container {
-  flex: 0 0 45%;
-  border-radius: 8px;
-  overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+.text-content {
+  max-height: 400px;
+  overflow-y: auto;
 }
 
-.image-box {
-  width: 100%;
-  height: auto;
-  display: block;
+.text-content::-webkit-scrollbar {
+  width: 10px;
 }
 
-.description {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  text-align: left;
+.text-content::-webkit-scrollbar-track {
+  background: transparent;
 }
 
-.description p {
+.text-content::-webkit-scrollbar-thumb {
+  background: #C7C7CC;
+  border-radius: 5px;
+  border: 2px solid #FFFFFF;
+}
+
+.text-content p {
   font-size: 14px;
   line-height: 1.7;
   color: #333;
-  margin: 0 0 20px 0;
+  margin: 0;
+  white-space: pre-wrap;
 }
 
-.btn-group {
+.image-content {
   display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.modal-btn {
-  display: inline-flex;
+  justify-content: center;
   align-items: center;
-  gap: 8px;
-  padding: 10px 16px;
+}
+
+.image-content img {
+  max-width: 100%;
+  max-height: 500px;
   border-radius: 8px;
-  text-decoration: none;
-  font-size: 13px;
-  font-weight: 500;
-  transition: all 0.2s ease;
-}
-
-.modal-btn.github {
-  background: #24292F;
-  color: white;
-}
-
-.modal-btn.github:hover {
-  background: #1B1F23;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-}
-
-.modal-btn.explore {
-  background: linear-gradient(180deg, #007AFF 0%, #0056CC 100%);
-  color: white;
-}
-
-.modal-btn.explore:hover {
-  background: linear-gradient(180deg, #0066DD 0%, #004499 100%);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 122, 255, 0.3);
-}
-
-.modal-btn i {
-  font-size: 14px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 /* Vue 3 Transition classes */
@@ -285,21 +225,19 @@ onUnmounted(() => {
   }
 
   .modal-body {
-    flex-direction: column;
     padding: 16px;
-    gap: 16px;
   }
 
-  .modal-image-container {
-    flex: none;
+  .text-content {
+    max-height: 300px;
   }
 
-  .description p {
+  .text-content p {
     font-size: 13px;
   }
 
-  .btn-group {
-    justify-content: center;
+  .image-content img {
+    max-height: 350px;
   }
 }
 
@@ -316,9 +254,12 @@ onUnmounted(() => {
     padding: 12px;
   }
 
-  .modal-btn {
-    padding: 8px 12px;
-    font-size: 12px;
+  .text-content {
+    max-height: 250px;
+  }
+
+  .image-content img {
+    max-height: 280px;
   }
 }
 </style>

--- a/src/components/FinderEmu.vue
+++ b/src/components/FinderEmu.vue
@@ -1,16 +1,47 @@
 <template>
   <div class="finder">
-    <div class="grid">
-      <FinderItem name="CLARK"/>
-      <FinderItem name="Security Injections"/>
-      <FinderItem name="Markdown Editor"/>
-      <FinderItem name="Job Jar"/>
-      <FinderItem name="Lol CLI"/>
-      <FinderItem name="Phishing Visualization"/>
-      <FinderItem name="WWYDH"/>
-      <FinderItem name="Photo Spot"/>
-      <FinderItem name="HeRO"/>
-      <FinderItem name="Morning Briefing"/>
+    <div class="finder-toolbar">
+      <div class="toolbar-left">
+        <button class="toolbar-btn" disabled>
+          <svg viewBox="0 0 16 16" fill="currentColor"><path d="M10.5 3L5.5 8l5 5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+        <button class="toolbar-btn" disabled>
+          <svg viewBox="0 0 16 16" fill="currentColor"><path d="M5.5 3L10.5 8l-5 5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+      </div>
+      <div class="toolbar-center">
+        <div class="breadcrumb">
+          <span class="breadcrumb-icon">📁</span>
+          <span class="breadcrumb-text">Projects</span>
+        </div>
+      </div>
+      <div class="toolbar-right">
+        <div class="view-toggle">
+          <button class="view-btn active" title="Icon view">
+            <svg viewBox="0 0 16 16"><rect x="2" y="2" width="5" height="5" rx="1" fill="currentColor"/><rect x="9" y="2" width="5" height="5" rx="1" fill="currentColor"/><rect x="2" y="9" width="5" height="5" rx="1" fill="currentColor"/><rect x="9" y="9" width="5" height="5" rx="1" fill="currentColor"/></svg>
+          </button>
+          <button class="view-btn" title="List view">
+            <svg viewBox="0 0 16 16"><rect x="2" y="3" width="12" height="2" rx="0.5" fill="currentColor"/><rect x="2" y="7" width="12" height="2" rx="0.5" fill="currentColor"/><rect x="2" y="11" width="12" height="2" rx="0.5" fill="currentColor"/></svg>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="finder-content">
+      <div class="grid">
+        <FinderItem name="CLARK"/>
+        <FinderItem name="Security Injections"/>
+        <FinderItem name="Markdown Editor"/>
+        <FinderItem name="Job Jar"/>
+        <FinderItem name="Lol CLI"/>
+        <FinderItem name="Phishing Visualization"/>
+        <FinderItem name="WWYDH"/>
+        <FinderItem name="Photo Spot"/>
+        <FinderItem name="HeRO"/>
+        <FinderItem name="Morning Briefing"/>
+      </div>
+    </div>
+    <div class="finder-status">
+      <span>10 items</span>
     </div>
     <ProjectModal :data="projectDataMap"/>
   </div>
@@ -117,28 +148,197 @@ const projectDataMap = new Map<string, ProjectData>([
 
 <style scoped>
 .finder {
-  color: black;
-  background-color: white;
-  height: 100%;
+  color: #1D1D1F;
+  background: linear-gradient(180deg, #FFFFFF 0%, #F5F5F7 100%);
+  height: calc(100% - 38px);
+  margin-top: 38px;
+  display: flex;
+  flex-direction: column;
+}
+
+.finder-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  background: linear-gradient(180deg, #F8F8F8 0%, #ECECEC 100%);
+  border-bottom: 1px solid #D1D1D1;
+  min-height: 32px;
+}
+
+.toolbar-left,
+.toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.toolbar-center {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.toolbar-btn {
+  width: 28px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #1D1D1F;
+  transition: background 0.15s ease;
+}
+
+.toolbar-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.toolbar-btn:not(:disabled):hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.toolbar-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 6px;
+}
+
+.breadcrumb-icon {
+  font-size: 14px;
+}
+
+.breadcrumb-text {
+  font-size: 13px;
+  font-weight: 500;
+  color: #1D1D1F;
+}
+
+.view-toggle {
+  display: flex;
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 6px;
+  padding: 2px;
+}
+
+.view-btn {
+  width: 26px;
+  height: 22px;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6E6E73;
+  transition: all 0.15s ease;
+}
+
+.view-btn.active {
+  background: white;
+  color: #1D1D1F;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.view-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
+.finder-content {
+  flex: 1;
   overflow: auto;
-  padding: 10px;
+  padding: 16px;
+}
+
+.finder-content::-webkit-scrollbar {
+  width: 14px;
+}
+
+.finder-content::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.finder-content::-webkit-scrollbar-thumb {
+  background: #C7C7CC;
+  border-radius: 7px;
+  border: 3px solid #F5F5F7;
+}
+
+.finder-content::-webkit-scrollbar-thumb:hover {
+  background: #A8A8AD;
 }
 
 .grid {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 5px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 8px;
+  justify-items: center;
 }
 
-/* Mobile */
-@media (max-width: 768px) {
+.finder-status {
+  padding: 4px 12px;
+  background: linear-gradient(180deg, #F8F8F8 0%, #ECECEC 100%);
+  border-top: 1px solid #D1D1D1;
+  font-size: 11px;
+  color: #6E6E73;
+  text-align: center;
+}
+
+@media only screen and (max-width: 768px) {
   .finder {
-    padding: 5px;
+    height: calc(100% - 32px);
+    margin-top: 32px;
+  }
+
+  .finder-toolbar {
+    padding: 4px 8px;
+    min-height: 28px;
+  }
+
+  .breadcrumb {
+    padding: 3px 8px;
+  }
+
+  .breadcrumb-text {
+    font-size: 12px;
   }
 
   .grid {
-    gap: 0;
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+    gap: 4px;
+  }
+
+  .finder-content {
+    padding: 12px;
+  }
+}
+
+@media only screen and (max-width: 480px) {
+  .toolbar-left,
+  .toolbar-right {
+    display: none;
+  }
+
+  .grid {
+    grid-template-columns: repeat(auto-fill, minmax(70px, 1fr));
+  }
+
+  .finder-content {
+    padding: 8px;
   }
 }
 </style>

--- a/src/components/FinderEmu.vue
+++ b/src/components/FinderEmu.vue
@@ -2,17 +2,17 @@
   <div class="finder">
     <div class="finder-toolbar">
       <div class="toolbar-left">
-        <button class="toolbar-btn" disabled>
+        <button class="toolbar-btn" :disabled="!canGoBack" @click="goBack">
           <svg viewBox="0 0 16 16" fill="currentColor"><path d="M10.5 3L5.5 8l5 5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
-        <button class="toolbar-btn" disabled>
+        <button class="toolbar-btn" :disabled="!canGoForward" @click="goForward">
           <svg viewBox="0 0 16 16" fill="currentColor"><path d="M5.5 3L10.5 8l-5 5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
       </div>
       <div class="toolbar-center">
         <div class="breadcrumb">
-          <span class="breadcrumb-icon">📁</span>
-          <span class="breadcrumb-text">Projects</span>
+          <span class="breadcrumb-icon">{{ currentLocation.type === 'root' ? '📁' : '📂' }}</span>
+          <span class="breadcrumb-text">{{ breadcrumbText }}</span>
         </div>
       </div>
       <div class="toolbar-right">
@@ -28,29 +28,49 @@
     </div>
     <div class="finder-content">
       <div class="grid">
-        <FinderItem name="CLARK"/>
-        <FinderItem name="Security Injections"/>
-        <FinderItem name="Markdown Editor"/>
-        <FinderItem name="Job Jar"/>
-        <FinderItem name="Lol CLI"/>
-        <FinderItem name="Phishing Visualization"/>
-        <FinderItem name="WWYDH"/>
-        <FinderItem name="Photo Spot"/>
-        <FinderItem name="HeRO"/>
-        <FinderItem name="Morning Briefing"/>
+        <!-- Root view: show project folders -->
+        <template v-if="currentLocation.type === 'root'">
+          <FinderItem
+            v-for="name in projectNames"
+            :key="name"
+            :name="name"
+            @click="navigateToProject(name)"
+          />
+        </template>
+        <!-- Project view: show files -->
+        <template v-else>
+          <FileItem
+            v-for="file in currentProjectFiles"
+            :key="file.name"
+            :file="file"
+            @open-file="handleFileOpen(file)"
+          />
+        </template>
       </div>
     </div>
     <div class="finder-status">
-      <span>10 items</span>
+      <span>{{ statusText }}</span>
     </div>
-    <ProjectModal :data="projectDataMap"/>
+    <FileModal
+      :show="showFileModal"
+      :file="activeFile"
+      @close="showFileModal = false"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref, computed } from 'vue'
 import FinderItem from './FinderItem.vue'
-import ProjectModal from './ProjectModal.vue'
-import type { ProjectData } from './ProjectData'
+import FileItem from './FileItem.vue'
+import FileModal from './FileModal.vue'
+import type { ProjectData, FileItem as FileItemType } from './ProjectData'
+import { useFinderNavigation } from '../composables/useFinderNavigation'
+
+const { currentLocation, canGoBack, canGoForward, navigateTo, goBack, goForward } = useFinderNavigation()
+
+const showFileModal = ref(false)
+const activeFile = ref<FileItemType | null>(null)
 
 enum Projects {
   CLARK = 'CLARK',
@@ -65,20 +85,19 @@ enum Projects {
   MorningBriefing = 'Morning Briefing'
 }
 
+const projectNames = Object.values(Projects)
+
 const projectDataMap = new Map<string, ProjectData>([
   [Projects.CLARK, {
     description: `Developer on team responsible for implementing a Cybersecurity curriculum management platform to curate and share learning objectives in academia.
-    Application uses new web technologies and the MEAN stack as part of a project funded by the National Science Foundation.`,
+Application uses new web technologies and the MEAN stack as part of a project funded by the National Science Foundation.`,
     image: 'clark.png',
     githubUrl: '',
     exploreUrl: 'https://clark.center'
   }],
   [Projects.SecurityInjections, {
-    description: `Worked for the Computer and Information Sciences department in a small team as a lead developer responsible
-      for developing a web application used as a instructional tool for introductory Computer Science students
-      and other cyber-related majors.
-      The current iteration is a single-page web application that makes use of the Angular JavaScript framework and
-      template-based storage in order to dynamically generate instructional content from JSON.`,
+    description: `Worked for the Computer and Information Sciences department in a small team as a lead developer responsible for developing a web application used as a instructional tool for introductory Computer Science students and other cyber-related majors.
+The current iteration is a single-page web application that makes use of the Angular JavaScript framework and template-based storage in order to dynamically generate instructional content from JSON.`,
     image: 'threeo.jpg',
     githubUrl: '',
     exploreUrl: 'http://cis1.towson.edu/~cyber4all/modules/nanomodules/Integer_Error-CS0_C++_Demo.html'
@@ -102,19 +121,15 @@ const projectDataMap = new Map<string, ProjectData>([
     exploreUrl: ''
   }],
   [Projects.PhishingVisualization, {
-    description: `Angular based application aimed at visualizing current online phishing threats across the world. Data is retrieved
-      from PhishTank, and is presented in the form of geo-location data on a map, dynamic charts, and a filterable grid.
-      Makes use of the PhishTank API, Google Maps API, and FreeGeoIP API.`,
+    description: `Angular based application aimed at visualizing current online phishing threats across the world. Data is retrieved from PhishTank, and is presented in the form of geo-location data on a map, dynamic charts, and a filterable grid.
+Makes use of the PhishTank API, Google Maps API, and FreeGeoIP API.`,
     image: 'phishVisual.jpg',
     githubUrl: 'https://github.com/tylernhoward/phishing-threats',
     exploreUrl: 'http://phishing-threats.herokuapp.com'
   }],
   [Projects.WWYDH, {
-    description: `What Would You Do Here?: A semester project that involved continuing development on a web application for a nonprofit client. This application
-      aimed to encourage community involvement in Baltimore City, MD by making use of vacant lots for user-suggested projects
-      and events.
-      This project manifested as a PHP based website that relied on a mySQL database and several APIs. Used the Agile development
-      process to gather the client's requirements and input throughout the semester.`,
+    description: `What Would You Do Here?: A semester project that involved continuing development on a web application for a nonprofit client. This application aimed to encourage community involvement in Baltimore City, MD by making use of vacant lots for user-suggested projects and events.
+This project manifested as a PHP based website that relied on a mySQL database and several APIs. Used the Agile development process to gather the client's requirements and input throughout the semester.`,
     image: 'wwydh.jpg',
     githubUrl: 'https://github.com/tylernhoward/wwydh',
     exploreUrl: 'http://wwydh-2017.herokuapp.com'
@@ -126,24 +141,92 @@ const projectDataMap = new Map<string, ProjectData>([
     exploreUrl: ''
   }],
   [Projects.HeRO, {
-    description: `Worked in a small team through the Office and Technology Services at Towson University to create and deploy
-      a desktop application written in Visual Basic.
-      The application is a run-on-startup tool that provides help resources, videos, and relevant campus alerts to
-      instructor workstations throughout multiple campuses of Towson University. To ensure reliability across different
-      machines, the tool relies only on access to the web and a shared drive.`,
+    description: `Worked in a small team through the Office and Technology Services at Towson University to create and deploy a desktop application written in Visual Basic.
+The application is a run-on-startup tool that provides help resources, videos, and relevant campus alerts to instructor workstations throughout multiple campuses of Towson University. To ensure reliability across different machines, the tool relies only on access to the web and a shared drive.`,
     image: 'hero.jpg',
     githubUrl: '',
     exploreUrl: ''
   }],
   [Projects.MorningBriefing, {
-    description: `ASP.net application aimed at providing a dashboard for users with information regarding weather, news, and todos. Makes
-      use of the OpenWeatherMap API and the News API. Also includes globalization, theming, and the Entity framework among
-      other features.`,
+    description: `ASP.net application aimed at providing a dashboard for users with information regarding weather, news, and todos. Makes use of the OpenWeatherMap API and the News API. Also includes globalization, theming, and the Entity framework among other features.`,
     image: 'mornbrief.jpg',
     githubUrl: 'https://github.com/tylernhoward/morning-briefing',
     exploreUrl: ''
   }],
 ])
+
+const breadcrumbText = computed(() => {
+  if (currentLocation.value.type === 'root') {
+    return 'Projects'
+  }
+  return currentLocation.value.projectName
+})
+
+const currentProjectFiles = computed<FileItemType[]>(() => {
+  if (currentLocation.value.type !== 'project') return []
+
+  const projectName = currentLocation.value.projectName
+  const project = projectDataMap.get(projectName)
+  if (!project) return []
+
+  const files: FileItemType[] = []
+
+  // Always add README.txt with description
+  files.push({
+    name: 'README.txt',
+    type: 'text',
+    content: project.description
+  })
+
+  // Add screenshot.png if image exists
+  if (project.image) {
+    files.push({
+      name: 'screenshot.png',
+      type: 'image',
+      content: project.image
+    })
+  }
+
+  // Add GitHub.webloc if URL exists
+  if (project.githubUrl) {
+    files.push({
+      name: 'GitHub.webloc',
+      type: 'link-github',
+      content: project.githubUrl
+    })
+  }
+
+  // Add Demo.webloc if explore URL exists
+  if (project.exploreUrl) {
+    files.push({
+      name: 'Demo.webloc',
+      type: 'link-explore',
+      content: project.exploreUrl
+    })
+  }
+
+  return files
+})
+
+const statusText = computed(() => {
+  if (currentLocation.value.type === 'root') {
+    return `${projectNames.length} items`
+  }
+  return `${currentProjectFiles.value.length} items`
+})
+
+function navigateToProject(name: string) {
+  navigateTo({ type: 'project', projectName: name })
+}
+
+function handleFileOpen(file: FileItemType) {
+  if (file.type === 'link-github' || file.type === 'link-explore') {
+    window.open(file.content, '_blank', 'noopener,noreferrer')
+  } else {
+    activeFile.value = file
+    showFileModal.value = true
+  }
+}
 </script>
 
 <style scoped>

--- a/src/components/FinderItem.vue
+++ b/src/components/FinderItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <a class="item" @click="eventBus.emit('toggle-modal', name)">
+  <a class="item" @click="$emit('click')">
     <div class="folder">
       <div class="folder-back"></div>
       <div class="folder-tab"></div>
@@ -10,10 +10,12 @@
 </template>
 
 <script setup lang="ts">
-import { eventBus } from '../eventBus'
-
 defineProps<{
   name: string
+}>()
+
+defineEmits<{
+  click: []
 }>()
 </script>
 

--- a/src/components/FinderItem.vue
+++ b/src/components/FinderItem.vue
@@ -1,6 +1,10 @@
 <template>
   <a class="item" @click="eventBus.emit('toggle-modal', name)">
-    <div class="folder"/>
+    <div class="folder">
+      <div class="folder-back"></div>
+      <div class="folder-tab"></div>
+      <div class="folder-front"></div>
+    </div>
     <div class="label">{{ name }}</div>
   </a>
 </template>
@@ -15,118 +19,143 @@ defineProps<{
 
 <style scoped>
 .item {
-  margin: 15px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   text-decoration: none;
-  padding: 15px 10px 10px;
-  cursor: pointer;
+  padding: 12px 8px;
   border-radius: 8px;
-  transition: background-color 0.2s;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  width: 100%;
+  max-width: 100px;
 }
 
 .item:hover {
-  background-color: rgba(0, 0, 0, 0.05);
+  background: rgba(0, 122, 255, 0.1);
+}
+
+.item:hover .label {
+  color: #007AFF;
+}
+
+.item:active {
+  background: rgba(0, 122, 255, 0.2);
 }
 
 .folder {
-  width: 80px;
+  width: 64px;
   height: 52px;
   position: relative;
-  background-color: #5AC8FA;
-  border-radius: 0 6px 6px 6px;
-  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
-  margin: 0 auto;
+  transform-style: preserve-3d;
+  transition: transform 0.2s ease;
 }
 
-.folder::before {
-  content: '';
-  width: 40%;
-  height: 8px;
-  border-radius: 4px 4px 0 0;
-  background-color: #4AB8E8;
+.item:hover .folder {
+  transform: scale(1.05);
+}
+
+.folder-back {
   position: absolute;
-  top: -8px;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(180deg, #66BFFF 0%, #0A84FF 100%);
+  border-radius: 2px 8px 8px 8px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.3),
+    0 2px 8px rgba(10, 132, 255, 0.3);
+}
+
+.folder-tab {
+  position: absolute;
+  top: -6px;
   left: 0;
+  width: 28px;
+  height: 12px;
+  background: linear-gradient(180deg, #8DD0FF 0%, #5AC8FA 100%);
+  border-radius: 4px 8px 0 0;
+  clip-path: polygon(0 100%, 0 30%, 15% 0, 85% 0, 100% 30%, 100% 100%);
+}
+
+.folder-front {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 75%;
+  background: linear-gradient(180deg, #5AC8FA 0%, #007AFF 100%);
+  border-radius: 0 0 8px 8px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.4),
+    0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.folder-front::before {
+  content: '';
+  position: absolute;
+  top: 4px;
+  left: 8px;
+  right: 8px;
+  height: 3px;
+  background: rgba(255, 255, 255, 0.25);
+  border-radius: 2px;
 }
 
 .label {
-  color: #333;
-  padding-top: 10px;
-  font-size: 12px;
+  margin-top: 8px;
+  font-size: 11px;
+  font-weight: 400;
+  color: #1D1D1F;
   text-align: center;
-  word-wrap: break-word;
+  line-height: 1.3;
+  word-break: break-word;
   max-width: 90px;
-  margin: 0 auto;
+  transition: color 0.15s ease;
 }
 
-/* Tablet */
-@media (max-width: 1024px) {
+@media only screen and (max-width: 768px) {
   .item {
-    margin: 12px;
-    padding: 12px 8px 8px;
-  }
-
-  .folder {
-    width: 70px;
-    height: 45px;
-  }
-
-  .folder::before {
-    height: 7px;
-    top: -7px;
-  }
-
-  .label {
-    font-size: 11px;
+    padding: 8px 4px;
     max-width: 80px;
   }
-}
-
-/* Mobile */
-@media (max-width: 768px) {
-  .item {
-    margin: 8px;
-    padding: 10px 6px 6px;
-  }
 
   .folder {
-    width: 60px;
-    height: 40px;
-    border-radius: 0 4px 4px 4px;
+    width: 52px;
+    height: 42px;
   }
 
-  .folder::before {
-    height: 6px;
-    top: -6px;
-    border-radius: 3px 3px 0 0;
-  }
-
-  .label {
-    font-size: 10px;
-    padding-top: 8px;
-    max-width: 70px;
-  }
-}
-
-/* Small mobile */
-@media (max-width: 480px) {
-  .item {
-    margin: 5px;
-    padding: 8px 4px 4px;
-  }
-
-  .folder {
-    width: 50px;
-    height: 32px;
-  }
-
-  .folder::before {
-    height: 5px;
+  .folder-tab {
+    width: 22px;
+    height: 10px;
     top: -5px;
   }
 
   .label {
+    font-size: 10px;
+    max-width: 75px;
+    margin-top: 6px;
+  }
+}
+
+@media only screen and (max-width: 480px) {
+  .item {
+    padding: 6px 2px;
+    max-width: 70px;
+  }
+
+  .folder {
+    width: 44px;
+    height: 36px;
+  }
+
+  .folder-tab {
+    width: 18px;
+    height: 8px;
+    top: -4px;
+  }
+
+  .label {
     font-size: 9px;
-    max-width: 60px;
+    max-width: 65px;
   }
 }
 </style>

--- a/src/components/ProjectData.ts
+++ b/src/components/ProjectData.ts
@@ -4,3 +4,15 @@ export interface ProjectData {
     githubUrl: string;
     exploreUrl: string;
 }
+
+export type ViewLocation =
+    | { type: 'root' }
+    | { type: 'project'; projectName: string }
+
+export type FileType = 'text' | 'image' | 'link-github' | 'link-explore'
+
+export interface FileItem {
+    name: string
+    type: FileType
+    content: string
+}

--- a/src/components/ProjectModal.vue
+++ b/src/components/ProjectModal.vue
@@ -5,19 +5,29 @@
         <div class="modal-wrapper">
           <div class="modal-container" @click.stop>
             <div class="modal-bar">
-              <div class="modal-close" @click="closeModal"></div>
+              <div class="modal-traffic-lights">
+                <button class="modal-close" @click="closeModal" aria-label="Close">
+                  <svg viewBox="0 0 12 12"><path d="M3.5 3.5l5 5M8.5 3.5l-5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+                </button>
+                <div class="modal-circle minimize"></div>
+                <div class="modal-circle maximize"></div>
+              </div>
               <span class="modal-header">{{ name }}</span>
             </div>
             <div class="modal-body">
-              <img class="image-box" v-if="project?.image" :src="project.image" :alt="name"/>
+              <div class="modal-image-container" v-if="project?.image">
+                <img class="image-box" :src="project.image" :alt="name"/>
+              </div>
               <div class="description">
                 <p>{{ project?.description }}</p>
                 <div class="btn-group">
-                  <a class="modal-btn" v-if="project?.githubUrl" :href="project.githubUrl" target="_blank" rel="noopener">
-                    <i class="fab fa-github"></i> Github
+                  <a class="modal-btn github" v-if="project?.githubUrl" :href="project.githubUrl" target="_blank" rel="noopener noreferrer">
+                    <i class="fab fa-github"></i>
+                    <span>View on GitHub</span>
                   </a>
-                  <a class="modal-btn" v-if="project?.exploreUrl" :href="project.exploreUrl" target="_blank" rel="noopener">
-                    <i class="far fa-compass"></i> Explore
+                  <a class="modal-btn explore" v-if="project?.exploreUrl" :href="project.exploreUrl" target="_blank" rel="noopener noreferrer">
+                    <i class="fas fa-external-link-alt"></i>
+                    <span>Explore</span>
                   </a>
                 </div>
               </div>
@@ -55,18 +65,12 @@ function closeModal() {
   showModal.value = false
 }
 
-function handleEscape(e: KeyboardEvent) {
-  if (e.key === 'Escape') closeModal()
-}
-
 onMounted(() => {
   eventBus.on('toggle-modal', handleToggleModal)
-  document.addEventListener('keydown', handleEscape)
 })
 
 onUnmounted(() => {
   eventBus.off('toggle-modal', handleToggleModal)
-  document.removeEventListener('keydown', handleEscape)
 })
 </script>
 
@@ -74,11 +78,9 @@ onUnmounted(() => {
 .modal-mask {
   position: fixed;
   z-index: 1000;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.6);
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -87,58 +89,112 @@ onUnmounted(() => {
 
 .modal-wrapper {
   width: 100%;
-  max-width: 800px;
-  max-height: 90vh;
-  overflow: auto;
+  max-width: 700px;
 }
 
 .modal-container {
-  background-color: #fff;
-  border-radius: 8px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  width: 100%;
+  background: #FFFFFF;
+  border-radius: 12px;
+  box-shadow:
+    0 22px 70px 4px rgba(0, 0, 0, 0.25),
+    0 0 0 1px rgba(0, 0, 0, 0.1);
   overflow: hidden;
 }
 
 .modal-bar {
-  background-color: #e8e8e8;
-  padding: 8px 12px;
   display: flex;
   align-items: center;
-  gap: 10px;
+  height: 38px;
+  background: linear-gradient(180deg, #E8E8E8 0%, #D4D4D4 100%);
+  border-bottom: 1px solid #B8B8B8;
+  padding: 0 12px;
+  position: relative;
+}
+
+.modal-traffic-lights {
+  display: flex;
+  gap: 8px;
+  z-index: 2;
 }
 
 .modal-close {
   width: 12px;
   height: 12px;
-  background-color: #ff5f57;
   border-radius: 50%;
+  border: none;
+  background: linear-gradient(180deg, #FF6058 0%, #E14640 100%);
+  box-shadow:
+    0 0 0 0.5px rgba(0, 0, 0, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);
   cursor: pointer;
-  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: filter 0.15s ease;
+}
+
+.modal-close svg {
+  width: 8px;
+  height: 8px;
+  opacity: 0;
+  color: rgba(0, 0, 0, 0.5);
+  transition: opacity 0.15s ease;
+}
+
+.modal-bar:hover .modal-close svg {
+  opacity: 1;
 }
 
 .modal-close:hover {
-  opacity: 0.8;
+  filter: brightness(0.9);
+}
+
+.modal-circle {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 0.5px rgba(0, 0, 0, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+
+.modal-circle.minimize {
+  background: linear-gradient(180deg, #FFBF2F 0%, #DEA514 100%);
+}
+
+.modal-circle.maximize {
+  background: linear-gradient(180deg, #2ACB42 0%, #1AAB29 100%);
 }
 
 .modal-header {
-  font-size: 14px;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 13px;
+  font-weight: 600;
   color: #333;
-  font-weight: 500;
+  letter-spacing: -0.2px;
 }
 
 .modal-body {
   display: flex;
-  padding: 20px;
-  gap: 20px;
+  gap: 24px;
+  padding: 24px;
+}
+
+.modal-image-container {
+  flex: 0 0 45%;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 .image-box {
-  width: 45%;
-  max-width: 350px;
+  width: 100%;
   height: auto;
-  object-fit: contain;
-  border-radius: 4px;
-  flex-shrink: 0;
+  display: block;
 }
 
 .description {
@@ -146,43 +202,67 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  text-align: left;
 }
 
 .description p {
-  line-height: 1.7;
-  margin: 0 0 15px 0;
   font-size: 14px;
-  color: #444;
+  line-height: 1.7;
+  color: #333;
+  margin: 0 0 20px 0;
 }
 
 .btn-group {
   display: flex;
-  gap: 10px;
+  gap: 12px;
   flex-wrap: wrap;
 }
 
 .modal-btn {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  color: #333;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 8px;
   text-decoration: none;
-  padding: 8px 16px;
-  border-radius: 6px;
-  background-color: #f0f0f0;
   font-size: 13px;
-  transition: all 0.2s;
+  font-weight: 500;
+  transition: all 0.2s ease;
 }
 
-.modal-btn:hover {
-  background-color: #28262C;
-  color: #87FF65;
+.modal-btn.github {
+  background: #24292F;
+  color: white;
 }
 
-/* Transitions */
-.modal-enter-active,
+.modal-btn.github:hover {
+  background: #1B1F23;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.modal-btn.explore {
+  background: linear-gradient(180deg, #007AFF 0%, #0056CC 100%);
+  color: white;
+}
+
+.modal-btn.explore:hover {
+  background: linear-gradient(180deg, #0066DD 0%, #004499 100%);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 122, 255, 0.3);
+}
+
+.modal-btn i {
+  font-size: 14px;
+}
+
+/* Vue 3 Transition classes */
+.modal-enter-active {
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 .modal-leave-active {
-  transition: opacity 0.25s ease;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .modal-enter-from,
@@ -190,82 +270,55 @@ onUnmounted(() => {
   opacity: 0;
 }
 
-.modal-enter-active .modal-container,
-.modal-leave-active .modal-container {
-  transition: transform 0.25s ease;
-}
-
 .modal-enter-from .modal-container,
 .modal-leave-to .modal-container {
-  transform: scale(0.95);
+  transform: scale(0.95) translateY(10px);
 }
 
-/* Tablet */
-@media (max-width: 1024px) {
-  .modal-body {
-    padding: 15px;
-    gap: 15px;
-  }
-
-  .image-box {
-    width: 40%;
-  }
-
-  .description p {
-    font-size: 13px;
-  }
-}
-
-/* Mobile - stack vertically */
-@media (max-width: 768px) {
+@media only screen and (max-width: 768px) {
   .modal-mask {
-    padding: 10px;
+    padding: 12px;
+  }
+
+  .modal-bar {
+    height: 32px;
   }
 
   .modal-body {
     flex-direction: column;
-    padding: 15px;
-    gap: 15px;
+    padding: 16px;
+    gap: 16px;
   }
 
-  .image-box {
-    width: 100%;
-    max-width: none;
-    max-height: 200px;
-    object-fit: cover;
+  .modal-image-container {
+    flex: none;
   }
 
   .description p {
     font-size: 13px;
-    line-height: 1.6;
   }
 
   .btn-group {
     justify-content: center;
   }
-
-  .modal-btn {
-    padding: 10px 20px;
-  }
 }
 
-/* Small mobile */
-@media (max-width: 480px) {
+@media only screen and (max-width: 480px) {
+  .modal-mask {
+    padding: 8px;
+  }
+
   .modal-header {
-    font-size: 13px;
+    font-size: 12px;
   }
 
   .modal-body {
     padding: 12px;
   }
 
-  .description p {
-    font-size: 12px;
-  }
-
   .modal-btn {
+    padding: 8px 12px;
     font-size: 12px;
-    padding: 8px 14px;
   }
 }
 </style>

--- a/src/components/TerminalEmu.vue
+++ b/src/components/TerminalEmu.vue
@@ -1,10 +1,19 @@
 <template>
-  <div class="terminal">
+  <div class="terminal" @click="focusInput">
     <div class="termContent">
       <div class="output" v-if="output">{{ output }}</div>
       <div class="input-line">
-        <span class="prompt">{{ inputLabel }}&nbsp;</span>
-        <input v-on:keyup.enter="commandEntered" v-model="command" class="commandInput" autofocus/>
+        <span class="prompt">{{ inputLabel }}</span>
+        <span class="typed-text">{{ command }}</span><span class="cursor"></span>
+        <input
+          ref="inputRef"
+          v-on:keyup.enter="commandEntered"
+          v-model="command"
+          class="commandInput"
+          spellcheck="false"
+          autocomplete="off"
+          autocapitalize="off"
+        />
       </div>
     </div>
   </div>
@@ -19,9 +28,14 @@ defineProps<{
   inputLabel: string
 }>()
 
+const inputRef = ref<HTMLInputElement | null>(null)
 const output = ref('')
 const command = ref('')
 const history = ref<string[]>([])
+
+function focusInput() {
+  inputRef.value?.focus()
+}
 
 enum Command {
   Help = 'help',
@@ -150,74 +164,130 @@ function commandEntered() {
 
 onMounted(() => {
   output.value = `${printAbout()}\nEnter 'help' for list of commands\n`
+  focusInput()
 })
 </script>
 
 <style scoped>
 .terminal {
-  color: #87FF65;
-  background-color: #28262C;
-  height: 100%;
+  background: linear-gradient(180deg, #1E1E1E 0%, #161616 100%);
   overflow: auto;
+  height: calc(100% - 38px);
+  margin-top: 38px;
+  cursor: text;
+}
+
+.terminal::-webkit-scrollbar {
+  width: 14px;
+}
+
+.terminal::-webkit-scrollbar-track {
+  background: #1E1E1E;
+}
+
+.terminal::-webkit-scrollbar-thumb {
+  background: #3A3A3A;
+  border-radius: 7px;
+  border: 3px solid #1E1E1E;
+}
+
+.terminal::-webkit-scrollbar-thumb:hover {
+  background: #4A4A4A;
 }
 
 .termContent {
-  padding: 20px 15px;
+  padding: 12px 16px;
   text-align: left;
-  font-family: 'Monaco', 'Courier New', monospace;
-  font-size: 14px;
-  min-height: 100%;
+  font-family: 'SF Mono', 'Menlo', 'Monaco', 'Consolas', monospace;
+  font-size: 13px;
+  line-height: 1.6;
+  color: #C7C7C7;
 }
 
 .output {
   white-space: pre-wrap;
   word-break: break-word;
-  margin-bottom: 10px;
+  color: #E0E0E0;
+  margin-bottom: 8px;
 }
 
 .input-line {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
+  position: relative;
 }
 
 .prompt {
-  white-space: nowrap;
+  color: #32D74B;
+  font-weight: 500;
+  margin-right: 6px;
+  text-shadow: 0 0 10px rgba(50, 215, 75, 0.3);
+}
+
+.typed-text {
+  color: #FFFFFF;
+  white-space: pre;
 }
 
 .commandInput {
-  flex: 1;
-  min-width: 100px;
-  font-family: inherit;
-  font-size: inherit;
-  border: none;
-  background: transparent;
-  outline: none;
-  color: inherit;
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
   padding: 0;
+  border: none;
+  pointer-events: none;
 }
 
-/* Tablet */
-@media (max-width: 1024px) {
-  .termContent {
-    font-size: 13px;
-    padding: 15px 12px;
+.cursor {
+  display: inline-block;
+  width: 8px;
+  height: 17px;
+  background: #32D74B;
+  animation: blink 1s step-end infinite;
+  box-shadow: 0 0 8px rgba(50, 215, 75, 0.5);
+  flex-shrink: 0;
+}
+
+@keyframes blink {
+  0%, 50% {
+    opacity: 1;
+  }
+  51%, 100% {
+    opacity: 0;
   }
 }
 
-/* Mobile */
-@media (max-width: 768px) {
+/* Selection styling */
+.commandInput::selection {
+  background: rgba(50, 215, 75, 0.3);
+}
+
+.output::selection {
+  background: rgba(50, 215, 75, 0.3);
+}
+
+@media only screen and (max-width: 768px) {
+  .terminal {
+    height: calc(100% - 32px);
+    margin-top: 32px;
+  }
+
   .termContent {
     font-size: 12px;
-    padding: 12px 10px;
+    padding: 10px 12px;
+  }
+
+  .cursor {
+    width: 7px;
+    height: 15px;
   }
 }
 
-/* Small mobile */
-@media (max-width: 480px) {
+@media only screen and (max-width: 480px) {
   .termContent {
     font-size: 11px;
-    padding: 10px 8px;
+    padding: 8px 10px;
   }
 }
 </style>

--- a/src/components/Window.vue
+++ b/src/components/Window.vue
@@ -2,12 +2,30 @@
   <div class="container">
     <div class="window">
       <div class="bar">
-        <div class="circle-bar">
-          <div class="circle close" @click="showFinder = false; windowTitle = 'Terminal'"></div>
-          <div class="circle minimize" @click="toggleFinder"></div>
-          <div class="circle maximize"></div>
+        <div class="traffic-lights">
+          <button
+            class="traffic-light close"
+            @click="showFinder = false; windowTitle = 'Terminal'"
+            aria-label="Close"
+          >
+            <svg viewBox="0 0 12 12"><path d="M3.5 3.5l5 5M8.5 3.5l-5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+          </button>
+          <button
+            class="traffic-light minimize"
+            @click="toggleFinder"
+            aria-label="Minimize"
+          >
+            <svg viewBox="0 0 12 12"><path d="M2.5 6h7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+          </button>
+          <button
+            class="traffic-light maximize"
+            aria-label="Maximize"
+          >
+            <svg viewBox="0 0 12 12"><path d="M3 3h6v6H3z" stroke="currentColor" stroke-width="1.25" fill="none"/></svg>
+          </button>
         </div>
         <div class="title-bar">
+          <span class="window-icon">{{ showFinder ? '📁' : '⌘' }}</span>
           <span class="title">{{ windowTitle }}</span>
         </div>
       </div>
@@ -54,112 +72,143 @@ onUnmounted(() => {
   width: 100%;
   max-width: 900px;
   height: 50vh;
-  min-height: 300px;
-  box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.3);
-  border-radius: 6px;
+  width: 70%;
   overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-.bar {
-  height: 28px;
-  min-height: 28px;
-  background-color: #DBDBDB;
-  display: flex;
-  align-items: center;
-  padding: 0 8px;
+  border-radius: 10px;
+  box-shadow:
+    0 22px 70px 4px rgba(0, 0, 0, 0.25),
+    0 0 0 1px rgba(0, 0, 0, 0.1);
   position: relative;
 }
 
-.circle-bar {
+.bar {
+  position: absolute;
+  width: 100%;
+  height: 38px;
+  background: linear-gradient(180deg, #E8E8E8 0%, #D4D4D4 100%);
+  border-bottom: 1px solid #B8B8B8;
+  z-index: 99;
   display: flex;
-  gap: 6px;
+  align-items: center;
+  backdrop-filter: blur(20px);
+}
+
+.traffic-lights {
+  display: flex;
+  gap: 8px;
+  padding-left: 12px;
   z-index: 2;
 }
 
-.circle {
+.traffic-light {
   width: 12px;
   height: 12px;
   border-radius: 50%;
-  border: #cccccc solid 1px;
+  border: none;
   cursor: pointer;
-  transition: opacity 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: filter 0.15s ease;
 }
 
-.circle:hover {
-  opacity: 0.8;
+.traffic-light svg {
+  width: 8px;
+  height: 8px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  color: rgba(0, 0, 0, 0.5);
 }
 
-.circle.close {
-  background-color: #ff5f57;
+.bar:hover .traffic-light svg {
+  opacity: 1;
 }
 
-.circle.minimize {
-  background-color: #ffbd2e;
+.traffic-light.close {
+  background: linear-gradient(180deg, #FF6058 0%, #E14640 100%);
+  box-shadow:
+    0 0 0 0.5px rgba(0, 0, 0, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);
 }
 
-.circle.maximize {
-  background-color: #28c840;
+.traffic-light.close:hover {
+  filter: brightness(0.9);
+}
+
+.traffic-light.minimize {
+  background: linear-gradient(180deg, #FFBF2F 0%, #DEA514 100%);
+  box-shadow:
+    0 0 0 0.5px rgba(0, 0, 0, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+
+.traffic-light.minimize:hover {
+  filter: brightness(0.9);
+}
+
+.traffic-light.maximize {
+  background: linear-gradient(180deg, #2ACB42 0%, #1AAB29 100%);
+  box-shadow:
+    0 0 0 0.5px rgba(0, 0, 0, 0.15),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+
+.traffic-light.maximize:hover {
+  filter: brightness(0.9);
 }
 
 .title-bar {
   position: absolute;
-  left: 0;
-  right: 0;
-  text-align: center;
-  font-size: 13px;
-  color: #4d4d4d;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   pointer-events: none;
 }
 
-.window-content {
-  flex: 1;
-  overflow: auto;
+.window-icon {
+  font-size: 14px;
 }
 
-/* Tablet */
-@media (max-width: 1024px) {
-  .container {
-    padding: 0 15px;
-  }
-
-  .window {
-    height: 45vh;
-  }
+.title {
+  font-size: 13px;
+  font-weight: 500;
+  color: #333;
+  letter-spacing: -0.2px;
 }
 
-/* Mobile */
-@media (max-width: 768px) {
-  .container {
-    padding: 0 10px;
-  }
-
+@media only screen and (max-width: 768px) {
   .window {
-    height: 40vh;
-    min-height: 250px;
+    width: 95%;
+    height: 55vh;
   }
 
   .bar {
-    height: 24px;
-    min-height: 24px;
+    height: 32px;
   }
 
-  .circle {
+  .traffic-light {
     width: 10px;
     height: 10px;
   }
 
-  .title-bar {
+  .traffic-light svg {
+    width: 6px;
+    height: 6px;
+  }
+
+  .title {
     font-size: 12px;
   }
 }
 
-/* Small mobile */
-@media (max-width: 480px) {
+@media only screen and (max-width: 480px) {
   .window {
-    height: 35vh;
-    min-height: 200px;
+    width: 100%;
+    height: 50vh;
+    border-radius: 0;
   }
 }
 </style>

--- a/src/composables/useFinderNavigation.ts
+++ b/src/composables/useFinderNavigation.ts
@@ -1,0 +1,38 @@
+import { ref, computed } from 'vue'
+import type { ViewLocation } from '../components/ProjectData'
+
+export function useFinderNavigation() {
+    const currentLocation = ref<ViewLocation>({ type: 'root' })
+    const backStack = ref<ViewLocation[]>([])
+    const forwardStack = ref<ViewLocation[]>([])
+
+    const canGoBack = computed(() => backStack.value.length > 0)
+    const canGoForward = computed(() => forwardStack.value.length > 0)
+
+    function navigateTo(location: ViewLocation) {
+        backStack.value.push(currentLocation.value)
+        forwardStack.value = []
+        currentLocation.value = location
+    }
+
+    function goBack() {
+        if (!canGoBack.value) return
+        forwardStack.value.push(currentLocation.value)
+        currentLocation.value = backStack.value.pop()!
+    }
+
+    function goForward() {
+        if (!canGoForward.value) return
+        backStack.value.push(currentLocation.value)
+        currentLocation.value = forwardStack.value.pop()!
+    }
+
+    return {
+        currentLocation,
+        canGoBack,
+        canGoForward,
+        navigateTo,
+        goBack,
+        goForward
+    }
+}

--- a/src/eventBus.ts
+++ b/src/eventBus.ts
@@ -2,7 +2,6 @@ import mitt from 'mitt'
 
 type Events = {
   'toggle-finder': void
-  'toggle-modal': string | undefined
 }
 
 export const eventBus = mitt<Events>()


### PR DESCRIPTION
## Summary
- Modernize Terminal and Finder UI with authentic macOS styling (gradients, shadows, scrollbars)
- Convert Finder from modal-based to navigation-based project viewing
- Add back/forward navigation with history stack
- Display project files (README.txt, screenshot.png, .webloc links) with CSS file icons
