### PR TITLE
Fix display bug

### DIFF
--- a/src/components/Window.vue
+++ b/src/components/Window.vue
@@ -68,6 +68,10 @@ onUnmounted(() => {
   padding: 0 20px;
 }
 
+.window-content {
+    height: 100%;
+}
+
 .window {
   width: 100%;
   max-width: 900px;


### PR DESCRIPTION
Little display bug:

```
  .window-content {
    height: 100%;
  }
```
was missing from Window.vue after latest changes